### PR TITLE
Use .GetSetMethod(true) instead of .GetSetMethod()

### DIFF
--- a/NJection.LambdaConverter/Ast/Expressions/MemberReference/MemberReference.cs
+++ b/NJection.LambdaConverter/Ast/Expressions/MemberReference/MemberReference.cs
@@ -211,7 +211,7 @@ namespace NJection.LambdaConverter.Expressions
                 methodInfo = methodReference.GetActualMethod<MethodInfo>();
                 _isStatic = methodInfo.IsStatic;
 
-                if (propertyInfo.CanWrite && propertyInfo.GetSetMethod().Equals(methodInfo)) {
+                if (propertyInfo.CanWrite && propertyInfo.GetSetMethod(true).Equals(methodInfo)) {
                     Member = propertyInfo;
                     InternalType = propertyInfo.PropertyType;
                 }


### PR DESCRIPTION
.GetSetMethod() returns null (and thus crashes) if the setter is not public, but .SetMethod—introduced in
 .NET 4.5—returns the method even when it's private.

This fixes a crash when using the library for me.

@sagifogel If you do merge this, do you mind updating the NuGet package too? That way I can revert back to using NuGet over a local reference. Thanks!